### PR TITLE
Settings Sliders

### DIFF
--- a/front/src/app/app.component.html
+++ b/front/src/app/app.component.html
@@ -276,16 +276,16 @@
               <div class="col">
                 <h4 class="mt-4 mb-2 mx-0">Filter by HP</h4>
                 <div class="row">
-                  <mat-form-field class="col" appearance="fill">
+                  <div class="col">
                     <mat-label>Min HP</mat-label>
-                    <input matInput type="number" min="0" max="99" [(ngModel)]="settingsService.settings.minHP" name="minHP">
-                    <mat-icon matSuffix>percent</mat-icon>
-                  </mat-form-field>
-                  <mat-form-field class="col" appearance="fill">
+                    <p style="text-align: center;">{{settingsService.settings.minHP}}%</p>
+                    <mat-slider min="0" max="100" step="1" value="0" [(ngModel)]="settingsService.settings.minHP" name="minHP" style="width: 100%"></mat-slider>
+                  </div>
+                  <div class="col">
                     <mat-label>Max HP</mat-label>
-                    <input matInput type="number" min="1" max="100" [(ngModel)]="settingsService.settings.maxHP" name="maxHP">
-                    <mat-icon matSuffix>percent</mat-icon>
-                  </mat-form-field>
+                    <p style="text-align: center;">{{settingsService.settings.maxHP}}%</p>
+                    <mat-slider min="1" max="100" step="1" value="100" [(ngModel)]="settingsService.settings.maxHP" name="maxHP" style="width: 100%"></mat-slider>
+                  </div>
                 </div>
               </div>
             </div>
@@ -301,17 +301,15 @@
             <div class="row">
               <div class="col">
                 <h4 class="mt-4 mb-2 mx-0">Filter by Max Players.</h4>
-                <mat-form-field appearance="fill">
-                  <mat-label>Maximum Players</mat-label>
-                  <input matInput type="number" min="0" [(ngModel)]="settingsService.settings.maxPlayers" name="maxPlayers">
-                </mat-form-field>
+                <mat-label>Maximum Players</mat-label>
+                <p style="text-align: center;">{{settingsService.settings.maxPlayers}}</p>
+                <mat-slider min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.maxPlayers" name="maxPlayers" style="width: 100%"></mat-slider>
               </div>
               <div class="col">
                 <h4 class="mt-4 mb-2 mx-0">Filter by Min players.</h4>
-                <mat-form-field appearance="fill">
-                  <mat-label>Minimum Players</mat-label>
-                  <input matInput type="number" min="0" [(ngModel)]="settingsService.settings.minPlayers" name="minPlayers">
-                </mat-form-field>
+                <mat-label>Minimum Players</mat-label>
+                <p style="text-align: center;">{{settingsService.settings.minPlayers}}</p>
+                <mat-slider min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.minPlayers" name="minPlayers" style="width: 100%"></mat-slider>
               </div>
             </div>
             <div class="row flex-row-vertical">

--- a/front/src/app/app.component.html
+++ b/front/src/app/app.component.html
@@ -279,12 +279,12 @@
                   <div class="col">
                     <mat-label>Min HP</mat-label>
                     <p style="text-align: center;">{{settingsService.settings.minHP}}%</p>
-                    <mat-slider min="0" max="100" step="1" value="0" [(ngModel)]="settingsService.settings.minHP" name="minHP" style="width: 100%"></mat-slider>
+                    <mat-slider thumbLabel min="0" max="100" step="1" value="0" [(ngModel)]="settingsService.settings.minHP" name="minHP" style="width: 100%"></mat-slider>
                   </div>
                   <div class="col">
                     <mat-label>Max HP</mat-label>
                     <p style="text-align: center;">{{settingsService.settings.maxHP}}%</p>
-                    <mat-slider min="1" max="100" step="1" value="100" [(ngModel)]="settingsService.settings.maxHP" name="maxHP" style="width: 100%"></mat-slider>
+                    <mat-slider thumbLabel min="1" max="100" step="1" value="100" [(ngModel)]="settingsService.settings.maxHP" name="maxHP" style="width: 100%"></mat-slider>
                   </div>
                 </div>
               </div>
@@ -303,13 +303,13 @@
                 <h4 class="mt-4 mb-2 mx-0">Filter by Max Players.</h4>
                 <mat-label>Maximum Players</mat-label>
                 <p style="text-align: center;">{{settingsService.settings.maxPlayers}}</p>
-                <mat-slider min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.maxPlayers" name="maxPlayers" style="width: 100%"></mat-slider>
+                <mat-slider thumbLabel min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.maxPlayers" name="maxPlayers" style="width: 100%"></mat-slider>
               </div>
               <div class="col">
                 <h4 class="mt-4 mb-2 mx-0">Filter by Min players.</h4>
                 <mat-label>Minimum Players</mat-label>
                 <p style="text-align: center;">{{settingsService.settings.minPlayers}}</p>
-                <mat-slider min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.minPlayers" name="minPlayers" style="width: 100%"></mat-slider>
+                <mat-slider thumbLabel min="0" max="30" step="1" value="0" tickInterval="1" [(ngModel)]="settingsService.settings.minPlayers" name="minPlayers" style="width: 100%"></mat-slider>
               </div>
             </div>
             <div class="row flex-row-vertical">


### PR DESCRIPTION
Sorry again for doing a pull the wrong way last time!

I've checked your suggestions and did some changes. I've removed the mat form field around every slider and now it looks much better.

I've run into some troubles trying to position the % symbol close to the value of the slider, I ended up changing it to text instead so I could format it better. If you want to keep it as an input I think the easiest way of adding the % symbol is just putting it on the title of the slider like this

![9434c31cbe33c432cd7d6a0efff96b75](https://user-images.githubusercontent.com/95883676/201411790-4a60d1ff-e8cc-46d4-ab80-e0701eeb2b26.png)

this would allow to keep the value as an input so the user can click and edit it without touching the slider. I think the way I did it is functional and works just fine, but I'm clarifying just in case you wanna keep it like it was before!

I've also reverted the default values of the client sliders to the ones you had before (two zeroes) since as you mentioned it was working in a weird way with the default values I gave it in the earlier pull.

Have a nice day and feel free to tell me if you want me to help with anything else that isn't listed under the issues!